### PR TITLE
Add blob support for iOS

### DIFF
--- a/src/idb-cache.ts
+++ b/src/idb-cache.ts
@@ -2,6 +2,8 @@
  * @author Drecom Co.,Ltd. http://www.drecom.co.jp/
  */
 
+import canUseBlob from './utils/canUseBlob';
+
 const VERSION = 1;
 
 const STORE_NAME = {
@@ -15,8 +17,7 @@ const DATA_TYPE = {
   BLOB : 3,
 }
 
-// iPhone/iPod/iPad
-const isIOS = /iP(hone|(o|a)d);/.test(window.navigator.userAgent);
+const useBlob = canUseBlob();
 
 export default class IDBCache {
   public static ERROR = {
@@ -409,8 +410,7 @@ export default class IDBCache {
       console.warn('Is not supported type of value');
     }
 
-    // IndexedDB on iOS does not support blob
-    if(isIOS && meta.type === DATA_TYPE.BLOB){
+    if(useBlob && meta.type === DATA_TYPE.BLOB){
       const reader = new FileReader();
       reader.onload = () => {
         reader.onload = null;

--- a/src/idb-cache.ts
+++ b/src/idb-cache.ts
@@ -290,7 +290,7 @@ export default class IDBCache {
 
   private _cleanup(){
     this._open((db) => {
-      const removeKeys = new Set();
+      const removeKeys = new Set<string>();
       const nowSeconds = Math.floor(Date.now() / 1000);
       let tmpNowCount = this._metaCache.size;
       this._metaCache.forEach((meta, key) => {

--- a/src/idb-cache.ts
+++ b/src/idb-cache.ts
@@ -410,7 +410,7 @@ export default class IDBCache {
       console.warn('Is not supported type of value');
     }
 
-    if(useBlob && meta.type === DATA_TYPE.BLOB){
+    if(!useBlob && meta.type === DATA_TYPE.BLOB){
       const reader = new FileReader();
       reader.onload = () => {
         reader.onload = null;

--- a/src/utils/canUseBlob.ts
+++ b/src/utils/canUseBlob.ts
@@ -1,0 +1,21 @@
+export default function canUseBlob(): boolean {
+  const ua = navigator.userAgent;
+
+  const isIOS = /iP(hone|(o|a)d)/.test(ua)
+  if (isIOS) {
+    const iosVerRegexResult = /ip[honead]{2,4}(?:.*os\s(\w+)\slike\smac)/i.exec(ua);
+    if (iosVerRegexResult) {
+      const iosVer = iosVerRegexResult[1];
+      const iosVerNums = iosVer.split('_');
+      const iosVerStr
+        = ((iosVerNums[0] === undefined) ? '000' : iosVerNums[0].padStart(3, '0')) // major
+        + ((iosVerNums[1] === undefined) ? '000' : iosVerNums[1].padStart(3, '0')) // minor
+        + ((iosVerNums[2] === undefined) ? '000' : iosVerNums[2].padStart(3, '0')) // patch
+      // Less than iOS12.2 can not use blob
+      if (iosVerStr < '012002000') {
+        return false;
+      }
+    }
+  }
+  return true;
+}

--- a/src/utils/canUseBlob.ts
+++ b/src/utils/canUseBlob.ts
@@ -6,11 +6,11 @@ export default function canUseBlob(): boolean {
     const iosVerRegexResult = /ip[honead]{2,4}(?:.*os\s(\w+)\slike\smac)/i.exec(ua);
     if (iosVerRegexResult) {
       const iosVer = iosVerRegexResult[1];
-      const iosVerNums = iosVer.split('_');
+      const [major = '', minor = '', patch = ''] = iosVer.split('_');
       const iosVerStr
-        = ((iosVerNums[0] === undefined) ? '000' : ('000' + iosVerNums[0]).slice(-3))  // major
-        + ((iosVerNums[1] === undefined) ? '000' : ('000' + iosVerNums[1]).slice(-3))  // minor
-        + ((iosVerNums[2] === undefined) ? '000' : ('000' + iosVerNums[2]).slice(-3)); // patch
+        = ('000' + major).slice(-3)
+        + ('000' + minor).slice(-3)
+        + ('000' + patch).slice(-3);
       // Less than iOS12.2 can not use blob
       if (iosVerStr < '012002000') {
         return false;

--- a/src/utils/canUseBlob.ts
+++ b/src/utils/canUseBlob.ts
@@ -8,9 +8,9 @@ export default function canUseBlob(): boolean {
       const iosVer = iosVerRegexResult[1];
       const iosVerNums = iosVer.split('_');
       const iosVerStr
-        = ((iosVerNums[0] === undefined) ? '000' : iosVerNums[0].padStart(3, '0')) // major
-        + ((iosVerNums[1] === undefined) ? '000' : iosVerNums[1].padStart(3, '0')) // minor
-        + ((iosVerNums[2] === undefined) ? '000' : iosVerNums[2].padStart(3, '0')) // patch
+        = ((iosVerNums[0] === undefined) ? '000' : ('000' + iosVerNums[0]).slice(-3))  // major
+        + ((iosVerNums[1] === undefined) ? '000' : ('000' + iosVerNums[1]).slice(-3))  // minor
+        + ((iosVerNums[2] === undefined) ? '000' : ('000' + iosVerNums[2]).slice(-3)); // patch
       // Less than iOS12.2 can not use blob
       if (iosVerStr < '012002000') {
         return false;


### PR DESCRIPTION
Blob is available in iOS 12.2 and later.

Tested iOS versions
 - 10.3.1
 - 11.0.1
 - 12.1
 - 12.2
 - 12.4
 - 13.0
